### PR TITLE
feat: proxy

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,3 +16,4 @@ jobs:
         ./tests/integration/pre_run_script.sh"
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
+      modules: '["test_charm", "test_proxy"]'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops>=2,<3
 jinja2>=3,<4
-pydantic>=1,<2
+pydantic>=2,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops>=2,<3
 jinja2>=3,<4
+pydantic>=1,<2

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -12,6 +12,37 @@ tmate-ssh-server states.
 
 ---
 
+## <kbd>class</kbd> `CharmConfigInvalidError`
+Exception raised when a charm configuration is found to be invalid. 
+
+
+
+**Attributes:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+<a href="../src/state.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str)
+```
+
+Initialize a new instance of the CharmConfigInvalidError exception. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `CharmStateBaseError`
 Represents an error with charm state. 
 
@@ -24,7 +55,7 @@ Represents an error with charm state.
 ## <kbd>class</kbd> `InvalidCharmStateError`
 Represents an invalid charm state. 
 
-<a href="../src/state.py#L21"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -46,6 +77,40 @@ Initialize the error.
 
 ---
 
+## <kbd>class</kbd> `ProxyConfig`
+Configuration for accessing Jenkins through proxy. 
+
+
+
+**Attributes:**
+ 
+ - <b>`http_proxy`</b>:  The http proxy URL. 
+ - <b>`https_proxy`</b>:  The https proxy URL. 
+ - <b>`no_proxy`</b>:  Comma separated list of hostnames to bypass proxy. 
+
+
+
+
+---
+
+<a href="../src/state.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_env`
+
+```python
+from_env() → Optional[ForwardRef('ProxyConfig')]
+```
+
+Instantiate ProxyConfig from juju charm environment. 
+
+
+
+**Returns:**
+  ProxyConfig if proxy configuration is provided, None otherwise. 
+
+
+---
+
 ## <kbd>class</kbd> `State`
 The tmate-ssh-server operator charm state. 
 
@@ -54,13 +119,14 @@ The tmate-ssh-server operator charm state.
 **Attributes:**
  
  - <b>`ip_addr`</b>:  The host IP address of the given tmate-ssh-server unit. 
+ - <b>`proxy_config`</b>:  The proxy configuration to apply to services used by tmate. 
 
 
 
 
 ---
 
-<a href="../src/state.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -86,5 +152,6 @@ Initialize the state from charm.
 **Raises:**
  
  - <b>`InvalidCharmStateError`</b>:  if the network bind address was not of IPv4/IPv6. 
+ - <b>`CharmConfigInvalidError`</b>:  if there was something wrong with charm configuration values. 
 
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -89,6 +89,39 @@ Configuration for accessing Jenkins through proxy.
  - <b>`no_proxy`</b>:  Comma separated list of hostnames to bypass proxy. 
 
 
+---
+
+#### <kbd>property</kbd> model_computed_fields
+
+Get the computed fields of this model instance. 
+
+
+
+**Returns:**
+  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
+
+---
+
+#### <kbd>property</kbd> model_extra
+
+Get extra fields set during validation. 
+
+
+
+**Returns:**
+  A dictionary of extra fields, or `None` if `config.extra` is not set to `"allow"`. 
+
+---
+
+#### <kbd>property</kbd> model_fields_set
+
+Returns the set of fields that have been explicitly set on this model instance. 
+
+
+
+**Returns:**
+  A set of strings representing the fields that have been set,  i.e. that were not filled from defaults. 
+
 
 
 ---

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L121"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L140"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L200"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L215"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L197"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -9,21 +9,28 @@ Configurations and functions to operate tmate-ssh-server.
 ---------------
 - **APT_DEPENDENCIES**
 - **GIT_REPOSITORY_URL**
+- **TMATE_SERVICE_NAME**
 - **USER**
 - **GROUP**
 - **PORT**
 
 ---
 
-<a href="../src/tmate.py#L59"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
 ```python
-install_dependencies() → None
+install_dependencies(proxy_config: Optional[ProxyConfig] = None) → None
 ```
 
 Install dependenciese required to start tmate-ssh-server container. 
+
+
+
+**Args:**
+ 
+ - <b>`proxy_config`</b>:  The proxy configuration to enable for dockerd. 
 
 
 
@@ -34,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -59,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -84,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L157"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -108,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L121"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L196"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L200"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L197"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L196"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L140"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L215"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L216"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,7 +53,7 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
 
         try:
             self.unit.status = ops.MaintenanceStatus("Installing packages.")
-            tmate.install_dependencies()
+            tmate.install_dependencies(self.state.proxy_config)
         except tmate.DependencySetupError as exc:
             logger.error("Failed to install docker package, %s.", exc)
             raise

--- a/src/state.py
+++ b/src/state.py
@@ -88,7 +88,7 @@ class State:
         proxy_config: The proxy configuration to apply to services used by tmate.
     """
 
-    ip_addr: typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address, str, None]
+    ip_addr: typing.Optional[typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address, str]]
     proxy_config: typing.Optional[ProxyConfig]
 
     @classmethod

--- a/src/state.py
+++ b/src/state.py
@@ -4,9 +4,14 @@
 """tmate-ssh-server states."""
 import dataclasses
 import ipaddress
+import logging
+import os
 import typing
 
 import ops
+from pydantic import BaseModel, HttpUrl, ValidationError
+
+logger = logging.getLogger(__name__)
 
 DEBUG_SSH_INTEGRATION_NAME = "debug-ssh"
 
@@ -27,15 +32,64 @@ class InvalidCharmStateError(CharmStateBaseError):
         self.reason = reason
 
 
+class CharmConfigInvalidError(CharmStateBaseError):
+    """Exception raised when a charm configuration is found to be invalid.
+
+    Attributes:
+        msg: Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the CharmConfigInvalidError exception.
+
+        Args:
+            msg: Explanation of the error.
+        """
+        self.msg = msg
+
+
+class ProxyConfig(BaseModel):
+    """Configuration for accessing Jenkins through proxy.
+
+    Attributes:
+        http_proxy: The http proxy URL.
+        https_proxy: The https proxy URL.
+        no_proxy: Comma separated list of hostnames to bypass proxy.
+    """
+
+    http_proxy: typing.Optional[HttpUrl]
+    https_proxy: typing.Optional[HttpUrl]
+    no_proxy: typing.Optional[str]
+
+    @classmethod
+    def from_env(cls) -> typing.Optional["ProxyConfig"]:
+        """Instantiate ProxyConfig from juju charm environment.
+
+        Returns:
+            ProxyConfig if proxy configuration is provided, None otherwise.
+        """
+        http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+        https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+        no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+        if not http_proxy and not https_proxy:
+            return None
+        # Mypy doesn't understand str is supposed to be converted to HttpUrl by Pydantic.
+        return cls(
+            http_proxy=http_proxy, https_proxy=https_proxy, no_proxy=no_proxy  # type: ignore
+        )
+
+
 @dataclasses.dataclass(frozen=True)
 class State:
     """The tmate-ssh-server operator charm state.
 
     Attributes:
         ip_addr: The host IP address of the given tmate-ssh-server unit.
+        proxy_config: The proxy configuration to apply to services used by tmate.
     """
 
     ip_addr: typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address, str, None]
+    proxy_config: typing.Optional[ProxyConfig]
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "State":
@@ -49,14 +103,24 @@ class State:
 
         Raises:
             InvalidCharmStateError: if the network bind address was not of IPv4/IPv6.
+            CharmConfigInvalidError: if there was something wrong with charm configuration values.
         """
+        try:
+            proxy_config = ProxyConfig.from_env()
+        except ValidationError as exc:
+            logger.error("Invalid juju model proxy configuration, %s", exc)
+            raise CharmConfigInvalidError("Invalid model proxy configuration.") from exc
+
         binding = charm.model.get_binding("juju-info")
         if not binding:
-            return cls(ip_addr=None)
+            return cls(ip_addr=None, proxy_config=proxy_config)
         # If unable to get a casted IPvX address, it is not useful.
         # https://github.com/canonical/operator/blob/8a08e8e1b389fce4e7b54663863c4b2d06e72224/ops/model.py#L939-L947
         if isinstance(binding.network.bind_address, str):
             raise InvalidCharmStateError(
                 f"Invalid network bind address {binding.network.bind_address}."
             )
-        return cls(ip_addr=binding.network.bind_address if binding else None)
+
+        return cls(
+            ip_addr=binding.network.bind_address if binding else None, proxy_config=proxy_config
+        )

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -7,6 +7,7 @@ import base64
 import dataclasses
 import hashlib
 import ipaddress
+import logging
 
 # subprocess module is required to install and start docker daemon processes, the security
 # implications have been considered.
@@ -38,6 +39,8 @@ USER = "ubuntu"
 GROUP = "ubuntu"
 
 PORT = 10022
+
+logger = logging.getLogger(__name__)
 
 
 class DependencySetupError(Exception):
@@ -111,7 +114,8 @@ def install_dependencies(proxy_config: typing.Optional[state.ProxyConfig] = None
     try:
         _setup_docker(proxy_config=proxy_config)
     except DependencySetupError as exc:
-        raise DependencySetupError("Failed to setup Docker") from exc
+        logger.error("Error setting up Docker, %s", exc)
+        raise
 
 
 def install_keys(host_ip: typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address, str]) -> None:

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -84,7 +84,7 @@ def _setup_docker(proxy_config: typing.Optional[state.ProxyConfig] = None) -> No
         DOCKER_DAEMON_CONFIG_PATH.write_text(daemon_config, encoding="utf-8")
 
     try:
-        apt.add_package("docker.io")
+        apt.add_package("docker.io", update_cache=True)
     except (apt.PackageNotFoundError, apt.PackageError, subprocess.CalledProcessError) as exc:
         raise DependencySetupError("Failed to apt install Docker.") from exc
     passwd.add_group("docker")
@@ -105,8 +105,7 @@ def install_dependencies(proxy_config: typing.Optional[state.ProxyConfig] = None
             dependencies.
     """
     try:
-        apt.update()
-        apt.add_package(APT_DEPENDENCIES)
+        apt.add_package(APT_DEPENDENCIES, update_cache=True)
     except (apt.PackageNotFoundError, apt.PackageError, subprocess.CalledProcessError) as exc:
         raise DependencySetupError("Failed to install apt packages.") from exc
     try:

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -70,7 +70,8 @@ def _setup_docker(proxy_config: typing.Optional[state.ProxyConfig] = None) -> No
         proxy_config: The proxy configuration to enable for dockerd.
 
     Raises:
-        DependencySetupError: if there was a problem installing/setting up Docker.
+        PackageNotFoundError: if the Docker apt package was not found.
+        PackageError: if there was a problem installing up Docker apt package.
     """
     if proxy_config:
         environment = jinja2.Environment(
@@ -88,7 +89,7 @@ def _setup_docker(proxy_config: typing.Optional[state.ProxyConfig] = None) -> No
 
     try:
         apt.add_package("docker.io", update_cache=True)
-    except (apt.PackageNotFoundError, apt.PackageError, subprocess.CalledProcessError) as exc:
+    except (apt.PackageNotFoundError, apt.PackageError) as exc:
         logger.error("Failed to add docker package, %s.", exc)
         raise
     passwd.add_group("docker")
@@ -108,7 +109,7 @@ def install_dependencies(proxy_config: typing.Optional[state.ProxyConfig] = None
     try:
         apt.add_package(APT_DEPENDENCIES, update_cache=True)
         _setup_docker(proxy_config=proxy_config)
-    except (apt.PackageNotFoundError, apt.PackageError, subprocess.CalledProcessError) as exc:
+    except (apt.PackageNotFoundError, apt.PackageError) as exc:
         raise DependencySetupError("Failed to install apt packages.") from exc
 
 

--- a/templates/docker_daemon.json.j2
+++ b/templates/docker_daemon.json.j2
@@ -1,0 +1,7 @@
+{
+  "proxies": {
+    "http-proxy": "{{ HTTP_PROXY }}",
+    "https-proxy": "{{ HTTPS_PROXY }}",
+    "no-proxy": "{{ NO_PROXY }}"
+  }
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -163,8 +163,12 @@ http_access deny all"""
 async def machine_ip_fixture(machine: Machine) -> str:
     """The machine public IP address."""
 
-    def get_machine_ip_address():
-        """Get latest machine IP address."""
+    def get_machine_ip_address() -> typing.Optional[str]:
+        """Get latest machine IP address.
+
+        Returns:
+            The latest machine IP address if ready, None otherwise.
+        """
         latest_machine = machine.latest()
         addresses = latest_machine.data["addresses"]
         try:
@@ -183,4 +187,6 @@ async def machine_ip_fixture(machine: Machine) -> str:
 
     await wait_for(get_machine_ip_address)
 
-    return get_machine_ip_address()
+    # mypy doesn't understand that get_machine_ip_address has to be str from wait_for statement
+    # above.
+    return typing.cast(str, get_machine_ip_address())

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for tmate-ssh-server charm."""
+import logging
+
+from juju.machine import Machine
+from juju.model import Model
+from juju.unit import Unit
+from pytest_operator.plugin import OpsTest
+
+from .helpers import wait_for
+
+logger = logging.getLogger(__name__)
+
+
+async def test_proxy(
+    ops_test: OpsTest,
+    model: Model,
+    charm: str,
+    proxy_machine: Machine,
+    machine_ip: str,
+):
+    """
+    arrange: given a model configured with squid proxy ip address.
+    act: when tmate charm is deployed.
+    assert: proxy log contains docker access.
+    """
+    await model.set_config(
+        {
+            "juju-http-proxy": f"http://{machine_ip}:3218",
+            "juju-https-proxy": f"http://{machine_ip}:3218",
+        }
+    )
+
+    logger.info("Deplyoing tmate charm.")
+    app = await model.deploy(charm)
+    await model.wait_for_idle(apps=[app.name], wait_for_active=True)
+    unit: Unit = next(iter(app.units))
+
+    async def wait_for_access_log():
+        """Wait until access log contains proxy access logs from tmate charm to docker."""
+        (retcode, stdout, stderr) = await ops_test.juju(
+            "ssh", proxy_machine.entity_id, "sudo cat /var/log/squid/access.log"
+        )
+        assert retcode == 0, f"Failed read squid access log, {stdout} {stderr}"
+        logger.info("Squid access log: %s", stdout)
+        return unit.public_address in stdout and "ghcr.io" in stdout
+
+    await wait_for(wait_for_access_log)

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -38,8 +38,12 @@ async def test_proxy(
     await model.wait_for_idle(apps=[app.name], wait_for_active=True)
     unit: Unit = next(iter(app.units))
 
-    async def wait_for_access_log():
-        """Wait until access log contains proxy access logs from tmate charm to docker."""
+    async def wait_for_access_log() -> bool:
+        """Wait until access log contains proxy access logs from tmate charm to docker.
+
+        Returns:
+            Whether ghcr.io access was found in proxy log.
+        """
         (retcode, stdout, stderr) = await ops_test.juju(
             "ssh", proxy_machine.entity_id, "sudo cat /var/log/squid/access.log"
         )

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -10,7 +10,7 @@ from typing import Generic, TypeVar
 
 import factory
 
-from state import State
+from state import ProxyConfig, State
 
 T = TypeVar("T")
 
@@ -22,6 +22,24 @@ class BaseMetaFactory(Generic[T], factory.base.FactoryMetaClass):
     def __call__(cls, *args, **kwargs) -> T:  # noqa: N805
         """Used for type hints of factories."""  # noqa: DCO020
         return super().__call__(*args, **kwargs)  # noqa: DCO030
+
+
+# The attributes of these classes are generators for the attributes of the meta class
+# mypy incorrectly believes the factories don't support metaclass
+class ProxyConfigFactory(factory.Factory, metaclass=BaseMetaFactory[ProxyConfig]):  # type: ignore
+    # Docstrings have been abbreviated for factories, checking for docstrings on model attributes
+    # can be skipped.
+    """Generate PathInfos."""  # noqa: DCO060
+
+    class Meta:
+        """Configuration for factory."""  # noqa: DCO060
+
+        model = ProxyConfig
+        abstract = False
+
+    http_proxy = "http://proxy.address:3128"
+    https_proxy = "https://proxy.address:3128"
+    no_proxy = "http://hello.org,http://goodbye.org"
 
 
 # The attributes of these classes are generators for the attributes of the meta class
@@ -38,3 +56,4 @@ class StateFactory(factory.Factory, metaclass=BaseMetaFactory[State]):  # type: 
         abstract = False
 
     ip_addr = factory.Faker("ipv4")
+    proxy_config = factory.SubFactory(ProxyConfigFactory)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -12,6 +12,20 @@ import state
 from state import State
 
 
+def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given a monkeypatched os.environ mapping that contains invalid proxy values.
+    act: when charm state is initialized.
+    assert: CharmConfigInvalidError is raised.
+    """
+    monkeypatch.setattr(state.os, "environ", {"JUJU_CHARM_HTTP_PROXY": "INVALID_URL"})
+    mock_charm = MagicMock(spec=ops.CharmBase)
+    mock_charm.config = {}
+
+    with pytest.raises(state.CharmConfigInvalidError):
+        state.State.from_charm(mock_charm)
+
+
 def test_invalid_bind_address():
     """
     arrange: given mocked juju network.bind_address.

--- a/tests/unit/test_tmate.py
+++ b/tests/unit/test_tmate.py
@@ -70,7 +70,7 @@ def test__setup_docker_error(exception: type[Exception], monkeypatch: pytest.Mon
         tmate.apt, "add_package", MagicMock(spec=apt.add_package, side_effect=[exception])
     )
 
-    with pytest.raises(tmate.DependencySetupError):
+    with pytest.raises(exception):
         tmate._setup_docker()
 
 
@@ -93,21 +93,6 @@ def test_install_dependencies_apt_error(
     monkeypatch.setattr(
         tmate.apt, "add_package", MagicMock(spec=apt.add_package, side_effect=[exception])
     )
-
-    with pytest.raises(tmate.DependencySetupError):
-        tmate.install_dependencies()
-
-
-def test_install_dependencies_add_user_to_group_error(monkeypatch: pytest.MonkeyPatch):
-    """
-    arrange: given a monkeypatched passwd module that raises an exception.
-    act: when install_dependencies is called.
-    assert: DependencyInstallError is raised.
-    """
-    monkeypatch.setattr(tmate.apt, "update", MagicMock(spec=apt.update))
-    monkeypatch.setattr(tmate.apt, "add_package", MagicMock(spec=apt.add_package))
-    monkeypatch.setattr(tmate.passwd, "add_group", MagicMock(spec=tmate.passwd.add_group))
-    monkeypatch.setattr(tmate.passwd, "add_user_to_group", MagicMock(side_effect=[ValueError]))
 
     with pytest.raises(tmate.DependencySetupError):
         tmate.install_dependencies()


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds proxy support for tmate ssh charm.

### Rationale

Proxy for Docker so that it can be used in PS5 environments.

### Juju Events Changes

None.

### Module Changes

`state.py` - proxy config
`tmate.py` - install_dependencies now installs docker configuration for proxy.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
