### PR TITLE
fix: expose port 10022, wait for service before ActiveStatus

### DIFF
--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L248"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L247"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -91,7 +91,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +115,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L216"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L248"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -78,6 +78,7 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
             logger.error("Something went wrong initializing keys, %s.", exc)
             raise
 
+        self.unit.open_port("tcp", tmate.PORT)
         self.sshdebug.update_relation_data(host=str(self.state.ip_addr), fingerprints=fingerprints)
         self.unit.status = ops.ActiveStatus()
 

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -158,13 +158,12 @@ def _wait_for(
     min_wait_seconds = timedelta(seconds=timeout)
     while now - start_time < min_wait_seconds:
         if func():
-            break
+            return
         now = datetime.now()
         sleep(check_interval)
-    else:
-        if func():
-            return
-        raise TimeoutError()
+    if func():
+        return
+    raise TimeoutError()
 
 
 def start_daemon(address: str) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -122,7 +122,7 @@ def test__on_install(
     """
     arrange: given a monkeypatched tmate installation function calls.
     act: when _on_install is called.
-    assert: the unit is in active status.
+    assert: the unit is in active status and tmate ssh server port is opened.
     """
     monkeypatch.setattr(tmate, "install_dependencies", MagicMock(spec=tmate.install_dependencies))
     monkeypatch.setattr(tmate, "install_keys", MagicMock(spec=tmate.install_keys))
@@ -132,4 +132,5 @@ def test__on_install(
     mock_event = MagicMock(spec=ops.InstallEvent)
     charm._on_install(mock_event)
 
+    assert ops.Port(protocol="tcp", port=tmate.PORT) in charm.unit.opened_ports()
     assert charm.unit.status.name == "active"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Opens the tmate-ssh-server port for external network connectivity - to be used by `juju expose`.
Waits the tmate-ssh-server service to be active before updating unit status.

### Rationale

This is an openstack level security level firewall rule.
The tmate-ssh-server may not be active due to Docker/network/... whatever reasons, hence the waiting for active will report a more accurate status after the service has started.

### Juju Events Changes

None.

### Module Changes

`charm.py` now calls `unit.open_port()`
`tmate.py` now waits for service to be active before returning.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
