### PR TITLE
Enable service and add health check

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,6 @@ jobs:
     with:
       juju-channel: 3.1/stable
       provider: lxd
-      tmate-debug: true
       pre-run-script: |
         -c "chmod +x tests/integration/pre_run_script.sh
         ./tests/integration/pre_run_script.sh"

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -91,17 +91,6 @@ Configuration for accessing Jenkins through proxy.
 
 ---
 
-#### <kbd>property</kbd> model_computed_fields
-
-Get the computed fields of this model instance. 
-
-
-
-**Returns:**
-  A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects. 
-
----
-
 #### <kbd>property</kbd> model_extra
 
 Get extra fields set during validation. 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -13,10 +13,11 @@ Configurations and functions to operate tmate-ssh-server.
 - **USER**
 - **GROUP**
 - **PORT**
+- **SYSTEMD_UNIT_NOT_RUNNING_CODE**
 
 ---
 
-<a href="../src/tmate.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +42,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,12 +67,12 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L173"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-## <kbd>function</kbd> `is_running`
+## <kbd>function</kbd> `status`
 
 ```python
-is_running() → bool
+status() → DaemonStatus
 ```
 
 Check if the tmate-ssh-server service is running. 
@@ -90,7 +91,7 @@ Check if the tmate-ssh-server service is running.
 
 ---
 
-<a href="../src/tmate.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L208"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -115,7 +116,7 @@ Install unit files, enable and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L245"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -139,7 +140,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L287"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 
@@ -169,7 +170,7 @@ Generate the .tmate.conf values from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L296"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L314"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_stopped_containers`
 
@@ -190,6 +191,22 @@ Remove all stopped containers.
 
 ## <kbd>class</kbd> `DaemonError`
 Represents an error with the tmate-ssh-server daemon. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `DaemonStatus`
+The status of the tmate-ssh-server daemon. 
+
+
+
+**Attributes:**
+ 
+ - <b>`running`</b>:  True if the daemon is running, False otherwise. 
+ - <b>`status`</b>:  The status string of the daemon process. 
 
 
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L176"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `is_running`
 
@@ -82,9 +82,15 @@ Check if the tmate-ssh-server service is running.
   True if the tmate-ssh-server service is running, False otherwise. 
 
 
+
+**Raises:**
+ 
+ - <b>`DaemonStatusError`</b>:  if there was an error checking the status of tmate-ssh-server. 
+
+
 ---
 
-<a href="../src/tmate.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L198"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -109,7 +115,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L244"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L252"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -133,7 +139,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L268"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 
@@ -159,6 +165,15 @@ Generate the .tmate.conf values from generated keys.
 
 **Returns:**
  The tmate config file contents. 
+
+
+---
+
+## <kbd>class</kbd> `ContainerStopError`
+Represents an error while stopping a container. 
+
+
+
 
 
 ---

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,7 +66,7 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L181"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L173"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `is_running`
 
@@ -85,12 +85,12 @@ Check if the tmate-ssh-server service is running.
 
 **Raises:**
  
- - <b>`DaemonStatusError`</b>:  if there was an error checking the status of tmate-ssh-server. 
+ - <b>`DaemonError`</b>:  if there was an error checking the status of tmate-ssh-server. 
 
 
 ---
 
-<a href="../src/tmate.py#L198"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -110,12 +110,12 @@ Install unit files, enable and start daemon.
 
 **Raises:**
  
- - <b>`DaemonStartError`</b>:  if there was an error starting the tmate-ssh-server docker process. 
+ - <b>`DaemonError`</b>:  if there was an error starting the tmate-ssh-server docker process. 
 
 
 ---
 
-<a href="../src/tmate.py#L253"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L245"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -139,7 +139,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 
@@ -169,7 +169,7 @@ Generate the .tmate.conf values from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L296"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_stopped_containers`
 
@@ -190,24 +190,6 @@ Remove all stopped containers.
 
 ## <kbd>class</kbd> `DaemonError`
 Represents an error with the tmate-ssh-server daemon. 
-
-
-
-
-
----
-
-## <kbd>class</kbd> `DaemonStartError`
-Represents an error while starting tmate-ssh-server daemon. 
-
-
-
-
-
----
-
-## <kbd>class</kbd> `DaemonStatusError`
-Represents an error while checking the status of tmate-ssh-server daemon. 
 
 
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -98,7 +98,7 @@ Check if the tmate-ssh-server service is running.
 start_daemon(address: str) → None
 ```
 
-Install unit files and start daemon. 
+Install unit files, enable and start daemon. 
 
 
 
@@ -115,7 +115,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L252"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L253"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -139,7 +139,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 
@@ -169,7 +169,7 @@ Generate the .tmate.conf values from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L303"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_stopped_containers`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -68,6 +68,24 @@ Install key creation script and generate keys.
 
 <a href="../src/tmate.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
+## <kbd>function</kbd> `status`
+
+```python
+status() → bool
+```
+
+Check if the tmate-ssh-server service is running. 
+
+
+
+**Returns:**
+  True if the tmate-ssh-server service is running, False otherwise. 
+
+
+---
+
+<a href="../src/tmate.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
 ## <kbd>function</kbd> `start_daemon`
 
 ```python
@@ -91,7 +109,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -115,7 +133,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L247"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L256"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -169,11 +169,21 @@ Generate the .tmate.conf values from generated keys.
 
 ---
 
-## <kbd>class</kbd> `ContainerStopError`
-Represents an error while stopping a container. 
+<a href="../src/tmate.py#L303"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `remove_stopped_containers`
+
+```python
+remove_stopped_containers() → None
+```
+
+Remove all stopped containers. 
 
 
 
+**Raises:**
+ 
+ - <b>`DockerError`</b>:  if there was an error removing stopped containers. 
 
 
 ---
@@ -207,6 +217,15 @@ Represents an error while checking the status of tmate-ssh-server daemon.
 
 ## <kbd>class</kbd> `DependencySetupError`
 Represents an error while installing and setting up dependencies. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `DockerError`
+Represents an error using a docker command. 
 
 
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -75,12 +75,12 @@ Install key creation script and generate keys.
 status() → DaemonStatus
 ```
 
-Check if the tmate-ssh-server service is running. 
+Check the status of the tmate-ssh-server service. 
 
 
 
 **Returns:**
-  True if the tmate-ssh-server service is running, False otherwise. 
+  The status of the tmate-ssh-server daemon. 
 
 
 
@@ -91,7 +91,7 @@ Check if the tmate-ssh-server service is running.
 
 ---
 
-<a href="../src/tmate.py#L208"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L209"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -116,7 +116,7 @@ Install unit files, enable and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L263"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L264"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -140,7 +140,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L287"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L288"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 
@@ -170,7 +170,7 @@ Generate the .tmate.conf values from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L314"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L315"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_stopped_containers`
 

--- a/src-docs/tmate.py.md
+++ b/src-docs/tmate.py.md
@@ -16,7 +16,7 @@ Configurations and functions to operate tmate-ssh-server.
 
 ---
 
-<a href="../src/tmate.py#L102"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_dependencies`
 
@@ -41,7 +41,7 @@ Install dependenciese required to start tmate-ssh-server container.
 
 ---
 
-<a href="../src/tmate.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_keys`
 
@@ -66,12 +66,12 @@ Install key creation script and generate keys.
 
 ---
 
-<a href="../src/tmate.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L176"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-## <kbd>function</kbd> `status`
+## <kbd>function</kbd> `is_running`
 
 ```python
-status() → bool
+is_running() → bool
 ```
 
 Check if the tmate-ssh-server service is running. 
@@ -84,7 +84,7 @@ Check if the tmate-ssh-server service is running.
 
 ---
 
-<a href="../src/tmate.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `start_daemon`
 
@@ -109,7 +109,7 @@ Install unit files and start daemon.
 
 ---
 
-<a href="../src/tmate.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L244"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_fingerprints`
 
@@ -133,7 +133,7 @@ Get fingerprint from generated keys.
 
 ---
 
-<a href="../src/tmate.py#L256"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/tmate.py#L268"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_tmate_conf`
 
@@ -163,8 +163,26 @@ Generate the .tmate.conf values from generated keys.
 
 ---
 
+## <kbd>class</kbd> `DaemonError`
+Represents an error with the tmate-ssh-server daemon. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `DaemonStartError`
 Represents an error while starting tmate-ssh-server daemon. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `DaemonStatusError`
+Represents an error while checking the status of tmate-ssh-server daemon. 
 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -85,6 +85,10 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
 
     def _on_update_status(self, _: ops.UpdateStatusEvent) -> None:
         """Check the health of the workload and restart if necessary."""
+        if not self.state.ip_addr:
+            logger.warning("Unit address not assigned. Exit hook.")
+            return
+
         if not tmate.is_running():
             logger.error("tmate-ssh-server is not running. Will restart.")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -101,8 +101,8 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
                 tmate.remove_stopped_containers()
             except tmate.DockerError:
                 logger.exception("Failed to remove stopped containers.")
-
-        logger.debug("tmate-ssh-server is running:\n %s", tmate_status.status)
+        else:
+            logger.debug("tmate-ssh-server is running:\n %s", tmate_status.status)
 
         self.unit.status = ops.ActiveStatus()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -44,7 +44,7 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
         Raises:
             DependencyInstallError: if the dependencies required to start charm has failed.
             KeyInstallError: if the ssh-key installation and fingerprint generation failed.
-            DaemonStartError: if the workload daemon was unable to start.
+            DaemonError: if the workload daemon was unable to start.
         """
         if not self.state.ip_addr:
             logger.warning("Unit address not assigned.")
@@ -69,7 +69,7 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
         try:
             self.unit.status = ops.MaintenanceStatus("Starting tmate-ssh-server daemon.")
             tmate.start_daemon(address=str(self.state.ip_addr))
-        except tmate.DaemonStartError as exc:
+        except tmate.DaemonError as exc:
             logger.error("Failed to start tmate-ssh-server daemon, %s.", exc)
             raise
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,6 +90,12 @@ class TmateSSHServerOperatorCharm(ops.CharmBase):
 
             tmate.start_daemon(address=str(self.state.ip_addr))
 
+            logger.info("Removing stopped containers.")
+            try:
+                tmate.remove_stopped_containers()
+            except tmate.DockerError:
+                logger.exception("Failed to remove stopped containers.")
+
         self.unit.status = ops.ActiveStatus()
 
 

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -74,8 +74,8 @@ class FingerprintError(Exception):
     """Represents an error with generating fingerprints from public keys."""
 
 
-class ContainerStopError(Exception):
-    """Represents an error while stopping a container."""
+class DockerError(Exception):
+    """Represents an error using a docker command."""
 
 
 def _setup_docker(proxy_config: typing.Optional[state.ProxyConfig] = None) -> None:
@@ -298,3 +298,15 @@ def generate_tmate_conf(host: str) -> str:
         set -g tmate-server-ed25519-fingerprint {fingerprints.ed25519}
         """
     )
+
+
+def remove_stopped_containers() -> None:
+    """Remove all stopped containers.
+
+    Raises:
+        DockerError: if there was an error removing stopped containers.
+    """
+    try:
+        subprocess.check_call(["docker", "container", "prune", "-f"])  # nosec
+    except subprocess.CalledProcessError as exc:
+        raise DockerError("Failed to remove stopped containers.") from exc

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -187,10 +187,10 @@ def _wait_for(
 
 
 def status() -> DaemonStatus:
-    """Check if the tmate-ssh-server service is running.
+    """Check the status of the tmate-ssh-server service.
 
     Returns:
-        True if the tmate-ssh-server service is running, False otherwise.
+        The status of the tmate-ssh-server daemon.
 
     Raises:
         DaemonError: if there was an error checking the status of tmate-ssh-server.

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -196,6 +196,7 @@ def status() -> DaemonStatus:
         DaemonError: if there was an error checking the status of tmate-ssh-server.
     """
     try:
+        # Input to subprocess.check_output is trusted, as it is not user input.
         status_str = subprocess.check_output(["systemctl", "status", TMATE_SERVICE_NAME])  # nosec
     except subprocess.CalledProcessError as exc:
         if exc.returncode == SYSTEMD_UNIT_NOT_RUNNING_CODE:

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -61,6 +61,7 @@ class DaemonError(Exception):
 class DaemonStartError(DaemonError):
     """Represents an error while starting tmate-ssh-server daemon."""
 
+
 class DaemonStatusError(DaemonError):
     """Represents an error while checking the status of tmate-ssh-server daemon."""
 
@@ -71,6 +72,10 @@ class IncompleteInitError(Exception):
 
 class FingerprintError(Exception):
     """Represents an error with generating fingerprints from public keys."""
+
+
+class ContainerStopError(Exception):
+    """Represents an error while stopping a container."""
 
 
 def _setup_docker(proxy_config: typing.Optional[state.ProxyConfig] = None) -> None:
@@ -178,6 +183,9 @@ def is_running() -> bool:
 
     Returns:
         True if the tmate-ssh-server service is running, False otherwise.
+
+    Raises:
+        DaemonStatusError: if there was an error checking the status of tmate-ssh-server.
     """
     try:
         return systemd.service_running(TMATE_SERVICE_NAME)

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -54,8 +54,15 @@ class KeyInstallError(Exception):
     """Represents an error while installing/generating key files."""
 
 
-class DaemonStartError(Exception):
+class DaemonError(Exception):
+    """Represents an error with the tmate-ssh-server daemon."""
+
+
+class DaemonStartError(DaemonError):
     """Represents an error while starting tmate-ssh-server daemon."""
+
+class DaemonStatusError(DaemonError):
+    """Represents an error while checking the status of tmate-ssh-server daemon."""
 
 
 class IncompleteInitError(Exception):
@@ -164,6 +171,20 @@ def _wait_for(
     if func():
         return
     raise TimeoutError()
+
+
+def is_running() -> bool:
+    """Check if the tmate-ssh-server service is running.
+
+    Returns:
+        True if the tmate-ssh-server service is running, False otherwise.
+    """
+    try:
+        return systemd.service_running(TMATE_SERVICE_NAME)
+    except systemd.SystemdError as exc:
+        raise DaemonStatusError("Failed to check tmate-ssh-server status.") from exc
+    except TimeoutError as exc:
+        raise DaemonStatusError("Timed out waiting for tmate service status.") from exc
 
 
 def start_daemon(address: str) -> None:

--- a/src/tmate.py
+++ b/src/tmate.py
@@ -196,7 +196,7 @@ def is_running() -> bool:
 
 
 def start_daemon(address: str) -> None:
-    """Install unit files and start daemon.
+    """Install unit files, enable and start daemon.
 
     Args:
         address: The IP address to bind to.
@@ -214,6 +214,7 @@ def start_daemon(address: str) -> None:
     TMATE_SSH_SERVER_SERVICE_PATH.write_text(service_content, encoding="utf-8")
     try:
         systemd.daemon_reload()
+        systemd.service_enable(TMATE_SERVICE_NAME)
         systemd.service_start(TMATE_SERVICE_NAME)
         _wait_for(partial(systemd.service_running, TMATE_SERVICE_NAME), timeout=60 * 10)
     except systemd.SystemdError as exc:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -110,7 +110,7 @@ async def test_restart_of_inactive_service(
     assert retcode == 0, f"Error running docker ps command, {stdout}, {stderr}"
     assert "tmate-ssh-server" not in stdout, "tmate-ssh-server service is still running"
     (retcode, _, _) = await ops_test.juju(
-        "ssh", unit.entity_id, "--", "systemctl status --quiet is-active tmate-ssh-server"
+        "ssh", unit.entity_id, "--", "systemctl --quiet is-active tmate-ssh-server"
     )
     assert retcode != 0, "tmate-ssh-server service is still running"
 
@@ -118,7 +118,7 @@ async def test_restart_of_inactive_service(
         await unit.model.wait_for_idle(apps=[tmate_ssh_server.name], status=ActiveStatus.name)
 
     (retcode, stdout, stderr) = await ops_test.juju(
-        "ssh", unit.entity_id, "--", "systemctl status --quiet is-active tmate-ssh-server"
+        "ssh", unit.entity_id, "--", "systemctl --quiet is-active tmate-ssh-server"
     )
     assert retcode == 0, f"tmate-ssh-server service is not running, {stdout}, {stderr}"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -96,7 +96,9 @@ async def test_ssh_connection(
     assert "test" in stdout, f"Failed to write with ssh command, {stdout}"
 
 
-async def test_restart_of_inactive_service(ops_test: OpsTest, unit: Unit, tmate_ssh_server: Application):
+async def test_restart_of_inactive_service(
+    ops_test: OpsTest, unit: Unit, tmate_ssh_server: Application
+):
     """
     arrange: given a tmate-ssh-server charm unit.
     act: kill the docker process containing the service and

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,6 +13,8 @@ from pytest_operator.plugin import OpsTest
 
 from tmate import PORT
 
+SHELL_STDOUT_LOG_STR = "Shell stdout: %s"
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,7 +22,7 @@ async def test_ssh_connection(
     ops_test: OpsTest, tmate_config: str, unit: Unit, tmate_machine: Machine, pub_key: str
 ):
     """
-    arrange: given a related github-runner charm and a tmate-ssh-server charm.
+    arrange: given a related machine charm and a tmate-ssh-server charm.
     act: when ssh connection is requested.
     assert: the connection is made successfully.
     """
@@ -76,17 +78,46 @@ async def test_ssh_connection(
     session.get_pty()
     session.invoke_shell()
     stdout = session.recv(10000)
-    logger.info("Shell stdout: %s", str(stdout))
+    logger.info(SHELL_STDOUT_LOG_STR, str(stdout))
     # The send expects bytes type but the docstrings want str type (bytes type doesn't work).
     session.send("q\n")  # type: ignore
     stdout = session.recv(10000)
-    logger.info("Shell stdout: %s", str(stdout))
+    logger.info(SHELL_STDOUT_LOG_STR, str(stdout))
     session.send("echo test > ~/test.txt && cat ~/test.txt\n")  # type: ignore
     stdout = session.recv(10000)
-    logger.info("Shell stdout: %s", str(stdout))
+    logger.info(SHELL_STDOUT_LOG_STR, str(stdout))
     (retcode, stdout, stderr) = await ops_test.juju(
         "ssh", tmate_machine.entity_id, "cat ~/test.txt"
     )
 
     assert retcode == 0, f"Error running ssh command, {stdout}, {stderr}"
     assert "test" in stdout, f"Failed to write with ssh command, {stdout}"
+
+
+async def test_restart_of_inactive_service(ops_test: OpsTest, unit: Unit):
+    """
+    arrange: given a tmate-ssh-server charm unit.
+    act: kill the docker process containing the service and
+     fast-forward to next update status event.
+    assert: the service has been restarted successfully.
+    """
+    await ops_test.juju("ssh", unit.entity_id, "--", "docker stop $(docker ps -q)")
+    (retcode, stdout, stderr) = await ops_test.juju("ssh", unit.entity_id, "--", "docker ps")
+    assert retcode == 0, f"Error running docker ps command, {stdout}, {stderr}"
+    assert "tmate-ssh-server" not in stdout, "tmate-ssh-server service is still running"
+    (retcode, _, _) = await ops_test.juju(
+        "ssh", unit.entity_id, "--", "systemctl status --quiet is-active tmate-ssh-server"
+    )
+    assert retcode != 0, "tmate-ssh-server service is still running"
+
+    async with ops_test.fast_forward():
+        await unit.model.wait_for_idle(idle_period=30, apps=[unit.app.name], status="active")
+
+    (retcode, stdout, stderr) = await ops_test.juju(
+        "ssh", unit.entity_id, "--", "systemctl status --quiet is-active tmate-ssh-server"
+    )
+    assert retcode == 0, f"tmate-ssh-server service is not running, {stdout}, {stderr}"
+
+    (retcode, stdout, stderr) = await ops_test.juju("ssh", unit.entity_id, "--", "docker ps")
+    assert retcode == 0, f"Error running docker ps command, {stdout}, {stderr}"
+    assert "tmate-ssh-server" in stdout, "tmate-ssh-server service is not running"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -136,6 +136,34 @@ def test__on_install(
     assert charm.unit.status.name == "active"
 
 
+def test__on_update_status_ip_not_assigned(
+    monkeypatch: pytest.MonkeyPatch,
+    charm: TmateSSHServerOperatorCharm,
+):
+    """
+    arrange: given a monkeypatched state.ip_addr that does not yet have a value.
+    act: when _on_update_status is called.
+    assert: the charm returns and calls no other functions.
+    """
+    is_running_mock = MagicMock(return_value=True)
+    start_daemon_mock = MagicMock(spec=tmate.start_daemon)
+    remove_stopped_containers_mock = MagicMock(spec=tmate.remove_stopped_containers)
+    monkeypatch.setattr(tmate, "is_running", is_running_mock)
+    monkeypatch.setattr(tmate, "start_daemon", start_daemon_mock)
+    monkeypatch.setattr(tmate, "remove_stopped_containers", remove_stopped_containers_mock)
+
+    mock_state = MagicMock(spec=State)
+    mock_state.ip_addr = None
+    monkeypatch.setattr(charm, "state", mock_state)
+
+    mock_event = MagicMock(spec=ops.UpdateStatusEvent)
+    charm._on_update_status(mock_event)
+
+    is_running_mock.assert_not_called()
+    start_daemon_mock.assert_not_called()
+    remove_stopped_containers_mock.assert_not_called()
+
+
 def test__on_update_status_error(
     monkeypatch: pytest.MonkeyPatch,
     charm: TmateSSHServerOperatorCharm,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -65,10 +65,10 @@ def test__on_install_daemon_error(
     monkeypatch.setattr(tmate, "install_dependencies", mock_install_deps)
     mock_install_keys = MagicMock(spec=tmate.install_keys)
     monkeypatch.setattr(tmate, "install_keys", mock_install_keys)
-    mock_install_deps = MagicMock(spec=tmate.start_daemon, side_effect=[tmate.DaemonStartError])
+    mock_install_deps = MagicMock(spec=tmate.start_daemon, side_effect=[tmate.DaemonError])
     monkeypatch.setattr(tmate, "start_daemon", mock_install_deps)
 
-    with pytest.raises(tmate.DaemonStartError):
+    with pytest.raises(tmate.DaemonError):
         charm._on_install(MagicMock(spec=ops.InstallEvent))
 
 
@@ -176,19 +176,19 @@ def test__on_update_status_error(
     assert: the errors are not caught
     """
     # 1. tmate.is_running raises an error
-    is_running_mock = MagicMock(side_effect=tmate.DaemonStatusError)
+    is_running_mock = MagicMock(side_effect=tmate.DaemonError)
     start_daemon_mock = MagicMock(spec=tmate.start_daemon)
     monkeypatch.setattr(tmate, "is_running", is_running_mock)
     monkeypatch.setattr(tmate, "start_daemon", start_daemon_mock)
 
-    with pytest.raises(tmate.DaemonStatusError):
+    with pytest.raises(tmate.DaemonError):
         charm._on_update_status(MagicMock(spec=ops.UpdateStatusEvent))
 
     # 2. tmate.is_running returns False and start_daemon raises an error
     is_running_mock.side_effect = [False]
-    start_daemon_mock.side_effect = tmate.DaemonStartError
+    start_daemon_mock.side_effect = tmate.DaemonError
 
-    with pytest.raises(tmate.DaemonStartError):
+    with pytest.raises(tmate.DaemonError):
         charm._on_update_status(MagicMock(spec=ops.UpdateStatusEvent))
 
 

--- a/tests/unit/test_tmate.py
+++ b/tests/unit/test_tmate.py
@@ -203,18 +203,12 @@ def test_start_daemon_daemon_reload_error(monkeypatch: pytest.MonkeyPatch):
 
 def test_is_running(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: given a monkeypatched systemd call that returns
-      1. True
-      2. False
+    arrange: given a monkeypatched systemd call.
     act: when is_running is called.
-    assert:
-      1. True is returned.
-      2. False is returned.
+    assert: the output of the systemd call is returned.
     """
     service_running_mock = MagicMock(spec=tmate.systemd.service_running, return_value=True)
-    monkeypatch.setattr(
-        tmate.systemd, "service_running", service_running_mock
-    )
+    monkeypatch.setattr(tmate.systemd, "service_running", service_running_mock)
 
     # 1. True is returned.
     assert tmate.is_running()
@@ -226,16 +220,14 @@ def test_is_running(monkeypatch: pytest.MonkeyPatch):
 
 def test_is_running_error(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: given a monkeypatched systemd call that raises
-     1. SystemdError
-     2. TimeoutError
+    arrange: given a monkeypatched systemd call that raises errors.
     act: when is_running is called.
     assert: DaemonStatusError is raised in both cases
     """
-    service_running_mock = MagicMock(spec=tmate.systemd.service_running, side_effect=tmate.systemd.SystemdError)
-    monkeypatch.setattr(
-        tmate.systemd, "service_running", service_running_mock
+    service_running_mock = MagicMock(
+        spec=tmate.systemd.service_running, side_effect=tmate.systemd.SystemdError
     )
+    monkeypatch.setattr(tmate.systemd, "service_running", service_running_mock)
 
     # 1. SystemdError is raised.
     with pytest.raises(tmate.DaemonStatusError) as exc:
@@ -352,12 +344,14 @@ def test_get_fingerprints(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
     monkeypatch.setattr(tmate, "RSA_PUB_KEY_PATH", MagicMock(spec=Path))
     monkeypatch.setattr(tmate, "ED25519_PUB_KEY_PATH", MagicMock(spec=Path))
+    rsa_fingerprint = "rsa"
+    ed25519_fingerprint = "ed25519"
     monkeypatch.setattr(
         tmate,
         "_calculate_fingerprint",
         MagicMock(
             spec=tmate._calculate_fingerprint,
-            side_effect=[(rsa_fingerprint := "rsa"), (ed25519_fingerprint := "ed25519")],
+            side_effect=[(rsa_fingerprint), (ed25519_fingerprint)],
         ),
     )
 

--- a/tests/unit/test_tmate.py
+++ b/tests/unit/test_tmate.py
@@ -275,7 +275,7 @@ def test_start_daemon_service_timeout_error(monkeypatch: pytest.MonkeyPatch):
 
 def test_start_daemon_service_start_error(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: given a monkeypatched subprocess call that raises CalledProcessError.
+    arrange: given a monkeypatched systemd that raises SystemdError.
     act: when start_daemon is called.
     assert: DaemonStartError is raised.
     """
@@ -337,7 +337,7 @@ def test_get_fingerprints_incomplete_init_error(monkeypatch: pytest.MonkeyPatch)
 
 def test_get_fingerprints(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: given a monkeypatched subprocess.check_output calls.
+    arrange: given a monkeypatched _calculate_fingerprint method.
     act: when get_fingerprints is called.
     assert: Correct fingerprint data is returned.
     """
@@ -404,3 +404,22 @@ def test_generate_tmate_conf(fingerprints: tmate.Fingerprints):
         )
         == tmate.generate_tmate_conf(host)
     )
+
+
+def test_remove_stopped_containers_error(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given a monkeypatched subprocess call that raises CalledProcessError.
+    act: when remove_stopped_containers is called.
+    assert: DockerError is raised.
+    """
+    monkeypatch.setattr(
+        tmate.subprocess,
+        "check_call",
+        MagicMock(
+            spec=tmate.subprocess.check_call,
+            side_effect=[tmate.subprocess.CalledProcessError(returncode=1, cmd="test")],
+        ),
+    )
+
+    with pytest.raises(tmate.DockerError):
+        tmate.remove_stopped_containers()

--- a/tests/unit/test_tmate.py
+++ b/tests/unit/test_tmate.py
@@ -195,7 +195,7 @@ def test_is_running_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched systemd call that raises errors.
     act: when is_running is called.
-    assert: DaemonStatusError is raised in both cases
+    assert: DaemonError is raised in both cases
     """
     service_running_mock = MagicMock(
         spec=tmate.systemd.service_running, side_effect=tmate.systemd.SystemdError
@@ -203,13 +203,13 @@ def test_is_running_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(tmate.systemd, "service_running", service_running_mock)
 
     # 1. SystemdError is raised.
-    with pytest.raises(tmate.DaemonStatusError) as exc:
+    with pytest.raises(tmate.DaemonError) as exc:
         tmate.is_running()
     assert "Failed to check tmate-ssh-server status." in str(exc.value)
 
     # 2. TimeoutError is raised.
     service_running_mock.side_effect = TimeoutError
-    with pytest.raises(tmate.DaemonStatusError) as exc:
+    with pytest.raises(tmate.DaemonError) as exc:
         tmate.is_running()
     assert "Timed out waiting for tmate service status." in str(exc.value)
 
@@ -218,7 +218,7 @@ def test_start_daemon_daemon_reload_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched systemd call that raises SystemdError.
     act: when start_daemon is called.
-    assert: DaemonStartError is raised.
+    assert: DaemonError is raised.
     """
     monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
     monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
@@ -235,7 +235,7 @@ def test_start_daemon_daemon_reload_error(monkeypatch: pytest.MonkeyPatch):
         ),
     )
 
-    with pytest.raises(tmate.DaemonStartError) as exc:
+    with pytest.raises(tmate.DaemonError) as exc:
         tmate.start_daemon(address="test")
 
     assert "Failed to start tmate-ssh-server daemon." in str(exc.value)
@@ -245,7 +245,7 @@ def test_start_daemon_service_timeout_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched _wait_for systemd service all that raises a timeout error.
     act: when start_daemon is called.
-    assert: DaemonStartError is raised.
+    assert: DaemonError is raised.
     """
     monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
     monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
@@ -272,7 +272,7 @@ def test_start_daemon_service_timeout_error(monkeypatch: pytest.MonkeyPatch):
         MagicMock(spec=tmate._wait_for, side_effect=TimeoutError),
     )
 
-    with pytest.raises(tmate.DaemonStartError) as exc:
+    with pytest.raises(tmate.DaemonError) as exc:
         tmate.start_daemon(address="test")
 
     assert "Timed out waiting for tmate service to start." in str(exc.value)
@@ -282,7 +282,7 @@ def test_start_daemon_enable_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched systemd call that raises SystemdError.
     act: when enable_daemon is called.
-    assert: DaemonStartError is raised.
+    assert: DaemonError is raised.
     """
     monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
     monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
@@ -304,7 +304,7 @@ def test_start_daemon_enable_error(monkeypatch: pytest.MonkeyPatch):
         ),
     )
 
-    with pytest.raises(tmate.DaemonStartError):
+    with pytest.raises(tmate.DaemonError):
         tmate.start_daemon(address="test")
 
 
@@ -312,7 +312,7 @@ def test_start_daemon_service_start_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched systemd that raises SystemdError.
     act: when start_daemon is called.
-    assert: DaemonStartError is raised.
+    assert: DaemonError is raised.
     """
     monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
     monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
@@ -337,7 +337,7 @@ def test_start_daemon_service_start_error(monkeypatch: pytest.MonkeyPatch):
         ),
     )
 
-    with pytest.raises(tmate.DaemonStartError):
+    with pytest.raises(tmate.DaemonError):
         tmate.start_daemon(address="test")
 
 

--- a/tests/unit/test_tmate.py
+++ b/tests/unit/test_tmate.py
@@ -174,33 +174,6 @@ def test__wait_for(monkeypatch: pytest.MonkeyPatch, timeout: int, interval: int)
     tmate._wait_for(mock_func, timeout=timeout, check_interval=interval)
 
 
-def test_start_daemon_daemon_reload_error(monkeypatch: pytest.MonkeyPatch):
-    """
-    arrange: given a monkeypatched systemd call that raises SystemdError.
-    act: when start_daemon is called.
-    assert: DaemonStartError is raised.
-    """
-    monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
-    monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
-    monkeypatch.setattr(tmate, "CREATE_KEYS_SCRIPT_PATH", MagicMock(spec=Path))
-    monkeypatch.setattr(tmate, "TMATE_SSH_SERVER_SERVICE_PATH", MagicMock(spec=Path))
-    monkeypatch.setattr(
-        tmate.systemd,
-        "daemon_reload",
-        MagicMock(
-            spec=tmate.systemd.daemon_reload,
-            side_effect=[
-                tmate.systemd.SystemdError,
-            ],
-        ),
-    )
-
-    with pytest.raises(tmate.DaemonStartError) as exc:
-        tmate.start_daemon(address="test")
-
-    assert "Failed to start tmate-ssh-server daemon." in str(exc.value)
-
-
 def test_is_running(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched systemd call.
@@ -241,6 +214,33 @@ def test_is_running_error(monkeypatch: pytest.MonkeyPatch):
     assert "Timed out waiting for tmate service status." in str(exc.value)
 
 
+def test_start_daemon_daemon_reload_error(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given a monkeypatched systemd call that raises SystemdError.
+    act: when start_daemon is called.
+    assert: DaemonStartError is raised.
+    """
+    monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
+    monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
+    monkeypatch.setattr(tmate, "CREATE_KEYS_SCRIPT_PATH", MagicMock(spec=Path))
+    monkeypatch.setattr(tmate, "TMATE_SSH_SERVER_SERVICE_PATH", MagicMock(spec=Path))
+    monkeypatch.setattr(
+        tmate.systemd,
+        "daemon_reload",
+        MagicMock(
+            spec=tmate.systemd.daemon_reload,
+            side_effect=[
+                tmate.systemd.SystemdError,
+            ],
+        ),
+    )
+
+    with pytest.raises(tmate.DaemonStartError) as exc:
+        tmate.start_daemon(address="test")
+
+    assert "Failed to start tmate-ssh-server daemon." in str(exc.value)
+
+
 def test_start_daemon_service_timeout_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched _wait_for systemd service all that raises a timeout error.
@@ -255,6 +255,11 @@ def test_start_daemon_service_timeout_error(monkeypatch: pytest.MonkeyPatch):
         tmate.systemd,
         "daemon_reload",
         MagicMock(spec=tmate.systemd.daemon_reload),
+    )
+    monkeypatch.setattr(
+        tmate.systemd,
+        "service_enable",
+        MagicMock(spec=tmate.systemd.service_enable),
     )
     monkeypatch.setattr(
         tmate.systemd,
@@ -273,6 +278,36 @@ def test_start_daemon_service_timeout_error(monkeypatch: pytest.MonkeyPatch):
     assert "Timed out waiting for tmate service to start." in str(exc.value)
 
 
+def test_start_daemon_enable_error(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given a monkeypatched systemd call that raises SystemdError.
+    act: when enable_daemon is called.
+    assert: DaemonStartError is raised.
+    """
+    monkeypatch.setattr(tmate, "WORK_DIR", MagicMock(spec=Path))
+    monkeypatch.setattr(tmate, "KEYS_DIR", MagicMock(spec=Path))
+    monkeypatch.setattr(tmate, "CREATE_KEYS_SCRIPT_PATH", MagicMock(spec=Path))
+    monkeypatch.setattr(tmate, "TMATE_SSH_SERVER_SERVICE_PATH", MagicMock(spec=Path))
+    monkeypatch.setattr(
+        tmate.systemd,
+        "daemon_reload",
+        MagicMock(spec=tmate.systemd.daemon_reload),
+    )
+    monkeypatch.setattr(
+        tmate.systemd,
+        "service_enable",
+        MagicMock(
+            spec=tmate.systemd.service_enable,
+            side_effect=[
+                tmate.systemd.SystemdError,
+            ],
+        ),
+    )
+
+    with pytest.raises(tmate.DaemonStartError):
+        tmate.start_daemon(address="test")
+
+
 def test_start_daemon_service_start_error(monkeypatch: pytest.MonkeyPatch):
     """
     arrange: given a monkeypatched systemd that raises SystemdError.
@@ -285,6 +320,11 @@ def test_start_daemon_service_start_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(tmate, "TMATE_SSH_SERVER_SERVICE_PATH", MagicMock(spec=Path))
     monkeypatch.setattr(
         tmate.systemd, "daemon_reload", MagicMock(spec=tmate.systemd.daemon_reload)
+    )
+    monkeypatch.setattr(
+        tmate.systemd,
+        "service_enable",
+        MagicMock(spec=tmate.systemd.service_enable),
     )
     monkeypatch.setattr(
         tmate.systemd,


### PR DESCRIPTION
### Overview

- Enable the tmate ssh service.
- Add a health check on the update status and restart the service if it is not running.

### Rationale
It may be that the service is not running, causing the tmate action to fail (e.g. [here](https://github.com/canonical/synapse-operator/actions/runs/7815426193/job/21321711056?pr=188)).

This may be because the service was not enabled and therefore not started after a reboot.


### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

add `on_update_status` handler


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
