### PR TITLE
fix: Lint error in test code due to wrong type

### DIFF
--- a/tests/unit/test_tmate.py
+++ b/tests/unit/test_tmate.py
@@ -41,7 +41,8 @@ def test_install_dependencies_proxy_config(monkeypatch: pytest.MonkeyPatch):
             "DOCKER_DAEMON_CONFIG_PATH",
             (tmp_file_path := Path(temporary_docker_daemon_file.name)),
         )
-        tmate.install_dependencies(proxy_config=proxy_config)
+        # ProxyConfigFactory is not considered as ProxyConfig for mypy
+        tmate.install_dependencies(proxy_config=proxy_config)  # type: ignore
 
         assert f"""{{
   "proxies": {{


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Fix a lint error.

### Rationale

Due to changes in `factory_boy` (they export type annotations since https://github.com/FactoryBoy/factory_boy/commit/336b72fa24f19581d2d226da893da103b2affdb2)


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
