### PR TITLE
chore: unpin flake8 dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ tst_path = {toxinidir}/tests/
 all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
-basepython = python3.10
+basepython = python3.12
 allowlist_externals=python
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}

--- a/tox.ini
+++ b/tox.ini
@@ -45,14 +45,14 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{[vars]tst_path}unit/requirements.txt
     black
-    flake8<6.0.0
-    flake8-docstrings>=1.6
-    flake8-copyright>=0.2
-    flake8-builtins>=2.0
-    flake8-docstrings-complete>=1.0.3
-    flake8-test-docs>=1.0
+    flake8
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    flake8-docstrings-complete
+    flake8-test-docs
     ; There is an error with version 6.0.0 related to integers and arguments
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pep8-naming
     isort
     codespell


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Unpin flake8 plugin dependency versions
<!-- A high level overview of the change -->

### Rationale

- To update the flake8 plugins which should then be compatible with Python 3.12 on noble runners.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

No user relevant changes

<!-- Explanation for any unchecked items above -->
